### PR TITLE
Update temperature_reader.py

### DIFF
--- a/pyspectator/temperature_reader.py
+++ b/pyspectator/temperature_reader.py
@@ -46,7 +46,7 @@ class LinuxCpuTemperatureReader():
 class WindowsCpuTemperatureReader():
 
     @classmethod
-    def get_reader():
+    def get_reader(cls):
         import wmi
         import pythoncom
 


### PR DESCRIPTION
The get_reader method of the WindowsTemp class can't accept the argument given, but adding cls fixes it.